### PR TITLE
251221

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -24,8 +24,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DART_SASS_VERSION: 1.97.0
-      HUGO_VERSION: 0.152.2
+      DART_SASS_VERSION: 1.97.1
+      HUGO_VERSION: 0.153.1
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bump Hugo to 0.153.1 and Dart Sass to 1.97.1 in `.github/workflows/hugo.yaml` build env.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f922d6e90b81048e1dac5cd2861da4a8d998d3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->