### PR TITLE
251223

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DART_SASS_VERSION: 1.97.1
-      HUGO_VERSION: 0.153.1
+      HUGO_VERSION: 0.153.2
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI update**
> 
> - Bumps `HUGO_VERSION` in `.github/workflows/hugo.yaml` from `0.153.1` to `0.153.2` for the build/deploy pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daaff7510e844be750f966718e70d14d205108d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->