### PR TITLE
新增排行榜功能，更新菜单配置，调整权重，修改样式引入，更新文档快捷键说明

### DIFF
--- a/assets/sass/_rank.scss
+++ b/assets/sass/_rank.scss
@@ -1,0 +1,426 @@
+.rank-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
+
+  .rank-tab {
+    padding: 12px 24px;
+    border: 2px solid var(--link-color);
+    background: var(--bg-color);
+    color: var(--link-color);
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    i {
+      font-size: 1.1rem;
+    }
+
+    &:hover {
+      background: var(--link-color);
+      color: #fff;
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    &.active {
+      background: var(--link-color);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+  }
+}
+
+.rank-filter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 24px;
+
+  label {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-color);
+  }
+
+  select {
+    padding: 8px 16px;
+    border: 2px solid var(--link-color);
+    border-radius: 8px;
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+
+    &:hover,
+    &:focus {
+      outline: none;
+      border-color: var(--link-color);
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+    }
+  }
+}
+
+.content.rank {
+  background: var(--bg-color);
+
+  .loading {
+    text-align: center;
+    padding: 60px 20px;
+    font-size: 1.2rem;
+    color: var(--text-color);
+
+    i {
+      margin-right: 8px;
+      color: var(--link-color);
+    }
+  }
+
+  .error {
+    text-align: center;
+    padding: 60px 20px;
+    color: #e74c3c;
+    font-size: 1.1rem;
+
+    i {
+      margin-right: 8px;
+    }
+  }
+
+  .rank-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0;
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  .rank-item {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+    background: var(--bg-color);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 12px;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+
+    .rank-header {
+      display: contents;
+    }
+
+    &:hover {
+      transform: translateX(4px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      border-color: var(--link-color);
+    }
+
+    &.top-1,
+    &.top-2,
+    &.top-3 {
+      background: linear-gradient(
+        135deg,
+        var(--bg-color) 0%,
+        var(--bg-color) 90%,
+        rgba(255, 215, 0, 0.1) 100%
+      );
+
+      .rank-number {
+        font-weight: 700;
+      }
+    }
+
+    &.top-1 .rank-number {
+      color: #ffd700;
+      text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+    }
+
+    &.top-2 .rank-number {
+      color: #c0c0c0;
+      text-shadow: 0 0 10px rgba(192, 192, 192, 0.5);
+    }
+
+    &.top-3 .rank-number {
+      color: #cd7f32;
+      text-shadow: 0 0 10px rgba(205, 127, 50, 0.5);
+    }
+
+    .rank-number {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--text-color);
+      min-width: 40px;
+      text-align: center;
+
+      i {
+        font-size: 1.8rem;
+      }
+    }
+
+    .rank-cover {
+      width: 80px;
+      height: auto;
+      max-height: 120px;
+      border-radius: 8px;
+      object-fit: contain;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      flex-shrink: 0;
+    }
+
+    .rank-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-width: 0;
+
+      .rank-title {
+        font-size: 1.15rem;
+        font-weight: 600;
+        color: var(--link-color);
+        margin: 0;
+        text-decoration: none;
+        transition: color 0.3s;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &:hover {
+          color: var(--link-hover-color);
+          text-decoration: underline;
+        }
+      }
+
+      .rank-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        font-size: 0.9rem;
+        color: #888;
+
+        .meta-item {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+
+          i {
+            color: var(--link-color);
+          }
+        }
+      }
+    }
+
+    .rank-value {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 4px;
+      flex-shrink: 0;
+
+      .value-number {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--link-color);
+      }
+
+      .value-label {
+        font-size: 0.85rem;
+        color: #888;
+      }
+
+      .value-trend {
+        font-size: 0.8rem;
+        padding: 2px 8px;
+        border-radius: 4px;
+        margin-top: 4px;
+
+        &.up {
+          color: #27ae60;
+          background: rgba(39, 174, 96, 0.1);
+        }
+
+        &.down {
+          color: #e74c3c;
+          background: rgba(231, 76, 60, 0.1);
+        }
+
+        i {
+          margin-right: 2px;
+        }
+      }
+    }
+  }
+
+  .no-data {
+    text-align: center;
+    padding: 60px 20px;
+    color: #888;
+    font-size: 1.1rem;
+
+    i {
+      font-size: 3rem;
+      margin-bottom: 16px;
+      color: #ccc;
+      display: block;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .rank-tabs {
+    .rank-tab {
+      padding: 10px 16px;
+      font-size: 0.9rem;
+
+      i {
+        font-size: 1rem;
+      }
+    }
+  }
+
+  .rank-filter {
+    flex-direction: row;
+    gap: 8px;
+
+    select {
+      padding: 6px 12px;
+    }
+  }
+
+  .content.rank {
+    .rank-item {
+      padding: 12px;
+      gap: 12px;
+
+      .rank-number {
+        font-size: 1.2rem;
+        min-width: 30px;
+      }
+
+      .rank-cover {
+        width: 70px;
+        max-height: 105px;
+      }
+
+      .rank-info {
+        .rank-title {
+          font-size: 1rem;
+        }
+
+        .rank-meta {
+          font-size: 0.85rem;
+          gap: 8px;
+        }
+      }
+
+      .rank-value {
+        .value-number {
+          font-size: 1.3rem;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .rank-tabs {
+    gap: 8px;
+
+    .rank-tab {
+      padding: 8px 12px;
+      font-size: 0.85rem;
+      flex: 1;
+
+      i {
+        font-size: 0.9rem;
+      }
+    }
+  }
+
+  .rank-filter {
+    label {
+      font-size: 0.9rem;
+    }
+
+    select {
+      padding: 6px 10px;
+      font-size: 0.9rem;
+    }
+  }
+
+  .content.rank {
+    .rank-item {
+      padding: 10px;
+      flex-direction: column;
+      align-items: stretch;
+
+      .rank-header {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        width: 100%;
+      }
+
+      .rank-number {
+        font-size: 1.1rem;
+        min-width: 28px;
+      }
+
+      .rank-cover {
+        width: 60px;
+        max-height: 90px;
+      }
+
+      .rank-info {
+        flex: 1;
+        min-width: 0;
+
+        .rank-title {
+          font-size: 0.95rem;
+          white-space: normal;
+          line-height: 1.3;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+
+        .rank-meta {
+          font-size: 0.75rem;
+          gap: 6px;
+          flex-wrap: wrap;
+        }
+      }
+
+      .rank-value {
+        width: 100%;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        padding-top: 8px;
+        border-top: 1px solid rgba(0, 0, 0, 0.05);
+
+        .value-number {
+          font-size: 1.2rem;
+        }
+
+        .value-label {
+          font-size: 0.8rem;
+        }
+      }
+    }
+  }
+}
+

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -9,3 +9,4 @@
 @use "./dls";
 @use "./teams";
 @use "./links";
+@use "./rank";

--- a/content/docs/快捷键速查.md
+++ b/content/docs/快捷键速查.md
@@ -7,6 +7,8 @@ date: 2025-11-04T02:20:00
 
 <kbd>V</kbd> + <kbd>/</kbd> = 搜索
 
+<kbd>V</kbd> + <kbd>R</kbd> = 排行
+
 <kbd>V</kbd> + <kbd>H</kbd> = 首页
 
 <kbd>V</kbd> + <kbd>D</kbd> = 文档

--- a/content/rank.md
+++ b/content/rank.md
@@ -1,0 +1,7 @@
++++
+title = "浏览下载排行榜"
+layout = "rank"
+comments = false
++++
+
+加载排行榜数据中...

--- a/hugo.toml
+++ b/hugo.toml
@@ -88,67 +88,74 @@ pageRef = '/dls'
 weight = 10
 pre = "fa fa-download"
 
+[[menus.main]]
+identifier = "rank"
+name = '排行'
+pageRef = '/rank'
+weight = 11
+pre = "fa fa-ranking-star"
+
 [[menus.footer]]
 identifier = "teams"
 name = '团队'
 pageRef = '/teams'
-weight = 11
+weight = 12
 pre = "fa fa-people-group"
 
 [[menus.footer]]
 identifier = "cloud"
 name = '云盘'
 url = 'https://cloud.saop.cc/'
-weight = 12
+weight = 13
 pre = "fa fa-cloud"
 
 [[menus.footer]]
 identifier = "drive"
 name = '网盘'
 url = 'https://drive.saop.cc/'
-weight = 13
+weight = 14
 pre = "fa fa-hard-drive"
 
 [[menus.main]]
 identifier = "live"
 name = '云游'
 pageRef = '/live'
-weight = 14
+weight = 15
 pre = "fa fa-gamepad"
 
 [[menus.main]]
 identifier = "post"
 name = '投稿'
 pageRef = '/post'
-weight = 15
+weight = 16
 pre = "fa fa-pen"
 
 [[menus.footer]]
 identifier = "donate"
 name = '捐赠'
 pageRef = '/donate'
-weight = 16
+weight = 17
 pre = "fa fa-hand-holding-dollar"
 
 [[menus.footer]]
 identifier = "links"
 name = '友链'
 pageRef = '/links'
-weight = 17
+weight = 18
 pre = "fa fa-link"
 
 [[menus.footer]]
 identifier = "feedback"
 name = '问卷'
 pageRef = '/feedback'
-weight = 18
+weight = 19
 pre = "fa fa-file-lines"
 
 [[menus.footer]]
 identifier = "ads"
 name = '广告'
 pageRef = '/ads'
-weight = 19
+weight = 20
 pre = "fa fa-rectangle-ad"
 
 [markup.goldmark.renderer]

--- a/layouts/rank.html
+++ b/layouts/rank.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<article class="article-main">
+  {{ partial "h1.html" . }}
+
+  <div class="rank-tabs">
+    <button class="rank-tab active" data-type="views">
+      <i class="fas fa-eye"></i> 浏览
+    </button>
+    <button class="rank-tab" data-type="downloads">
+      <i class="fas fa-download"></i> 下载
+    </button>
+  </div>
+
+  <div class="rank-filter">
+    <label for="days-select">时间范围:</label>
+    <select id="days-select">
+      <option value="1">今日</option>
+      <option value="7">近7天</option>
+      <option value="30" selected>近30天</option>
+    </select>
+  </div>
+
+  <div class="content rank" id="rank-content">
+    <div class="loading"><i class="fas fa-spinner fa-spin"></i> 加载中...</div>
+  </div>
+</article>
+{{ end }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a full rankings feature and wires it into the site.
> 
> - New `rank` page (`content/rank.md`) with template `layouts/rank.html` providing tabs (浏览/下载) and a days filter (1/7/30)
> - Implements `initRankPage()` in `assets/js/main.js` to fetch `views`/`downloads` data, render ranked items, handle tab/time-range switches, and formats numbers; hooked into page init
> - Extends keyboard shortcuts to include `V+R` => `/rank/`
> - Adds styles for the rankings UI in `assets/sass/_rank.scss` and imports them in `assets/sass/style.scss`
> - Updates `hugo.toml` menus: adds main "排行" entry and adjusts weights of existing items accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5077a02cee697049fdfcb1e266bfae99ea4dee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->