### PR TITLE
Update main.js firework particle configurations to use circles and ad…

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -53,33 +53,51 @@ loaderEl.addEventListener("click", endLoading);
 function mouseFirework() {
   firework({
     excludeElements: [],
-    particles: [
+    "particles": [
       {
-        shape: "polygon",
-        move: ["emit", "rotate"],
-        easing: "easeOutExpo",
-        colors: ["#ff324a", "#31ffa6", "#206eff", "#ffff99"],
-        number: 30,
-        duration: [1200, 1800],
-        shapeOptions: {
-          radius: [16, 32],
-          sides: 5,
-        },
+        "shape": "circle",
+        "move": [
+          "emit"
+        ],
+        "easing": "easeOutExpo",
+        "colors": [
+          "rgba(255,182,185,.9)",
+          "rgba(250,227,217,.9)",
+          "rgba(187,222,214,.9)",
+          "rgba(138,198,209,.9)"
+        ],
+        "number": 30,
+        "duration": [
+          1200,
+          1800
+        ],
+        "shapeOptions": {
+          "radius": [
+            16,
+            32
+          ]
+        }
       },
       {
-        shape: "polygon",
-        move: ["diffuse", "rotate"],
-        easing: "easeOutExpo",
-        colors: ["#FFF"],
-        number: 3,
-        duration: [1200, 1800],
-        shapeOptions: {
-          radius: 20,
-          alpha: 0.5,
-          lineWidth: 6,
-          sides: 5,
-        },
-      },
+        "shape": "circle",
+        "move": [
+          "diffuse"
+        ],
+        "easing": "easeOutExpo",
+        "colors": [
+          "#FFF"
+        ],
+        "number": 1,
+        "duration": [
+          1200,
+          1800
+        ],
+        "shapeOptions": {
+          "radius": 20,
+          "alpha": 0.5,
+          "lineWidth": 6
+        }
+      }
     ],
   });
 }

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -311,8 +311,8 @@ blockquote {
     right: 0px;
   }
   #waifu-tool {
-    left: 20px;
-    transform: translateX(-50%);
+    left: -200px;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
…just colors; modify _base.scss positioning for #waifu-tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines visual effects and UI positioning.
> 
> - Updates `mouseFirework` config in `assets/js/main.js`: replaces polygon particles with `shape: "circle"`, simplifies `move` (drops `rotate`), adjusts `colors` to pastel RGBA, reduces secondary particle `number` from 3→1, and tweaks `shapeOptions` (radius only)
> - Adjusts `assets/sass/_base.scss` for `#waifu-tool`: sets `left: -200px` and removes `transform` to change its revealed position
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e335ea9a8f82c7c3fff0a56765b36b30b694c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->