### PR TITLE
Update Hugo version to 0.155.0 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DART_SASS_VERSION: 1.97.3
-      HUGO_VERSION: 0.154.5
+      HUGO_VERSION: 0.155.0
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only version bump; risk is limited to potential build/regression differences introduced by the new Hugo release.
> 
> **Overview**
> Updates the GitHub Actions Hugo build workflow to use Hugo `0.155.0` (from `0.154.5`) when downloading and installing the Hugo CLI for site builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ecf92be1d0ec9dd93175a09ff648e5f2fa6c20a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->