### PR TITLE
Update Hugo version to 0.155.2 in GitHub Actions workflow and change …

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DART_SASS_VERSION: 1.97.3
-      HUGO_VERSION: 0.155.1
+      HUGO_VERSION: 0.155.2
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:

--- a/hugo.toml
+++ b/hugo.toml
@@ -22,7 +22,7 @@ pre = "fa fa-film"
 [[menus.main]]
 identifier = "multi-search"
 name = '聚搜'
-url = 'https://searchgal.homes/'
+url = 'https://searchgal.top/'
 weight = 1
 pre = "fa fa-hexagon-nodes"
 


### PR DESCRIPTION
…search URL in hugo.toml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-only changes: a Hugo patch-version bump in the build workflow and a single menu URL update, with minimal impact beyond potential build/link correctness.
> 
> **Overview**
> Updates the GitHub Actions Hugo deploy workflow to build with Hugo `0.155.2` (from `0.155.1`).
> 
> Changes the `multi-search` menu entry in `hugo.toml` to point from `https://searchgal.homes/` to `https://searchgal.top/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6634f04cbf89e9278ddfffa6b651b6e617b0d78a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->