### PR TITLE
Enhance loader styles by adjusting positioning, dimensions, and addin…

### DIFF
--- a/assets/sass/_loader.scss
+++ b/assets/sass/_loader.scss
@@ -1,24 +1,38 @@
 #loader {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  z-index: 1000;
   .loading-bg {
-    position: fixed;
+    position: absolute;
+    top: 0;
+    bottom: 0;
     z-index: 1000;
-    width: 50%;
-    height: 100%;
+    width: 50vw;
+    height: 100vh;
+    height: 100dvh;
     background-color: #ffffffe6;
     transition: 0.2s;
     backdrop-filter: blur(8px);
+  }
+  .loading-left-bg {
+    left: 0;
   }
   .loading-right-bg {
     right: 0;
   }
   .spinner-box {
-    position: fixed;
+    position: absolute;
+    inset: 0;
     z-index: 1001;
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 100%;
+    width: 100vw;
     height: 100vh;
+    height: 100dvh;
     opacity: 1;
     transition: 0.5s;
     .loading-taichi {
@@ -38,6 +52,7 @@
     }
   }
   &.loading {
+    pointer-events: none;
     .loading-left-bg {
       transform: translate(-100%);
     }


### PR DESCRIPTION
…g a loading-left-bg class for improved layout and responsiveness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to loader positioning/sizing; low risk aside from potential visual regressions across viewport units (e.g., `dvh`).
> 
> **Overview**
> Updates loader overlay styling to be truly full-screen by anchoring `#loader` to the viewport (`inset: 0`) and switching child elements from `fixed` to `absolute` positioning.
> 
> Adjusts dimensions to use viewport units (`vw`/`vh`/`dvh`) for more consistent sizing on mobile, introduces a `.loading-left-bg` class to explicitly pin the left panel, and disables pointer events while in the `.loading` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 955ab4025a1a8e4e550b79a569b913ed28b017a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->