### PR TITLE
feat: Integrate Busuanzi API for page view tracking and update Hugo v…

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DART_SASS_VERSION: 1.97.3
-      HUGO_VERSION: 0.156.0
+      HUGO_VERSION: 0.157.0
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -285,7 +285,10 @@ const SwupHooks = {
 };
 
 // 初始化
-document.addEventListener("DOMContentLoaded", initializePage);
+document.addEventListener("DOMContentLoaded", () => {
+  initializePage();
+  bszRe();
+});
 SwupHooks.init();
 
 function mouseFirework() {
@@ -351,13 +354,38 @@ function initMediumZoom() {
 }
 
 function bszRe() {
-  bszCaller.fetch(
-    "//busuanzi.ibruce.info/busuanzi?jsonpCallback=BusuanziCallback",
-    function (a) {
-      bszTag.texts(a);
-      bszTag.shows();
-    },
-  );
+  var bszAPI =
+    document.querySelector('meta[name="bsz-api"]')?.content;
+  if (!bszAPI) return;
+
+  fetch(bszAPI, {
+    method: "POST",
+    credentials: "include",
+    headers: { "x-bsz-referer": location.href },
+  })
+    .then((r) => r.json())
+    .then(({ success, data }) => {
+      if (!success) return;
+      const set = (id, val) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = val;
+      };
+      set("busuanzi_value_site_pv", data.site_pv);
+      set("busuanzi_value_site_uv", data.site_uv);
+      set("busuanzi_value_page_pv", data.page_pv);
+    })
+    .catch(() => {});
+
+  document.querySelectorAll("[data-bsz-href]").forEach((el) => {
+    fetch(bszAPI, {
+      headers: { "x-bsz-referer": el.dataset.bszHref },
+    })
+      .then((r) => r.json())
+      .then(({ success, data }) => {
+        if (success) el.textContent = data.page_pv;
+      })
+      .catch(() => {});
+  });
 }
 
 /**

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -121,6 +121,11 @@ main {
   }
   h2 {
     border-bottom: 1px solid #e0e0e0;
+    sup {
+      font-size: 0.5em;
+      color: #666;
+      margin-left: 0.2em;
+    }
   }
   h3 {
     border-bottom: 1px dotted #e0e0e0;

--- a/hugo.toml
+++ b/hugo.toml
@@ -180,6 +180,7 @@ defaultAuthor = "Asuna"
 ogImage = "img/logo.svg"
 logo = "/img/logo.svg"
 contentEdit = "https://github.com/AdingApkgg/vns/edit/dev/content/"
+bszAPI = "https://bsz.saop.cc/api"
 
 paginate = 10
 paginatePath = "page"

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -3,7 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="preconnect" href="https://registry.npmmirror.com/" crossorigin />
 <link rel="dns-prefetch" href="https://registry.npmmirror.com/" />
-<link rel="dns-prefetch" href="https://busuanzi.ibruce.info/" />
+{{ with .Site.Params.bszAPI }}<link rel="dns-prefetch" href="{{ . }}" />
+<meta name="bsz-api" content="{{ . }}" />{{ end }}
 <title>
   {{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title
   site.Title }}{{ end }}
@@ -39,11 +40,6 @@
       encodeURIComponent(window.location.href);
   }
 </script>
-<script
-  async
-  src="https://registry.npmmirror.com/js-asuna/latest/files/js/bsz.pure.mini.js"
-  fetchpriority="high"
-></script>
 <script
   src="/js/Swup.umd.js"
   fetchpriority="high"

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -17,8 +17,8 @@
     ],
   });
 
-  var meting_api =
-    "https://meting.qjqq.cn/?server=:server&type=:type&id=:id&auth=:auth&r=:r";
+  // var meting_api =
+  //   "https://meting.qjqq.cn/?server=:server&type=:type&id=:id&auth=:auth&r=:r";
 </script>
 <script src="https://registry.npmmirror.com/medium-zoom/latest/files/dist/medium-zoom.min.js"></script>
 {{ partialCached "head/js.html" . }}

--- a/layouts/docs.html
+++ b/layouts/docs.html
@@ -8,7 +8,7 @@
   range $paginator.Pages.ByLastmod.Reverse.ByWeight }}
   <section>
     <article>
-      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a><sup class="busuanzi_value_page_pv" data-bsz-href="{{ .Permalink }}"></sup></h2>
       {{ partial "post-meta.html" . }} {{ .Summary }}
     </article>
   </section>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -17,7 +17,7 @@
   "p") }} {{ range $paginator.Pages.ByLastmod.Reverse.ByWeight }}
   <section>
     <article>
-      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a><sup class="busuanzi_value_page_pv" data-bsz-href="{{ .Permalink }}"></sup></h2>
       {{ partial "post-meta.html" . }} {{ .Summary }} {{ partial "terms.html"
       (dict "taxonomy" "categories" "page" .) }} {{ partial "terms.html" (dict
       "taxonomy" "tags" "page" .) }}

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -4,7 +4,7 @@
     <i class="fas fa-hashtag"></i>&nbsp;{{ .Name }}<sup id="busuanzi_value_page_pv"></sup>
   </h1>
   {{ .Content }} {{ range .Pages }}
-  <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+  <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a><sup class="busuanzi_value_page_pv" data-bsz-href="{{ .Permalink }}"></sup></h2>
   {{ partial "post-meta.html" . }} {{ .Summary }} {{ end }}
 </article>
 {{ end }}


### PR DESCRIPTION
…ersion to 0.157.0

- Add bszAPI parameter in hugo.toml for Busuanzi API integration.
- Modify main.js to fetch and display page view data using the Busuanzi API.
- Update layouts to include page view elements in article headers.
- Adjust styles in _base.scss for superscript display in headings.
- Update GitHub Actions workflow to use Hugo version 0.157.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new client-side pageview fetching with cross-origin requests and cookie credentials, which could affect privacy/CORS behavior and runtime errors if the API response shape changes. Other changes are minor template/CSS tweaks and a Hugo version bump in CI.
> 
> **Overview**
> Replaces the previous Busuanzi script integration with a **configurable Busuanzi API** (`params.bszAPI`) injected via `head.html` and consumed by `bszRe()` in `main.js` to fetch and render site/page PV/UV, including per-link PV counts via `data-bsz-href`.
> 
> Updates list templates (`home.html`, `docs.html`, `term.html`) to display per-item PV counts in `h2` headings, adds `h2 sup` styling in `_base.scss`, removes the old external `bsz.pure.mini.js` include, and bumps CI Hugo from `0.156.0` to `0.157.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774c6ccd8ad421822bf732b1d74d01188d253414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->