### PR TITLE
Remove duplicate entry for 蛋窝 resource platform from links.json

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -141,10 +141,4 @@
     "url": "https://917878club.rf.gd/",
     "logo": "https://917878club.rf.gd/dan.jpg"
   }
-  {
-    "site": "蛋窝",
-    "desc": "一个永久免费的acg资源平台",
-    "url": "http://917878club.rf.gd/",
-    "logo": "http://917878club.rf.gd/dan.jpg"
-  }
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk data-only change that removes a duplicated list item; no logic or behavior changes beyond the resulting link list contents.
> 
> **Overview**
> Removes the duplicate `蛋窝` record from `data/links.json` (the older `http://` URL/logo variant), leaving a single `https://` entry in the links list.
> 
> No code changes—only the curated link data is updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08190d9fe284d6a2fccf2c6ac146f35128655e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->