### PR TITLE
Implement domain redirection and update Vercel configuration

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -1,4 +1,5 @@
 {{ hugo.Generator }}
+<script>if(location.host==="vns.saop.cc")location.replace("https://gal.saop.cc"+location.pathname+location.search+location.hash);</script>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="preconnect" href="https://registry.npmmirror.com/" crossorigin />

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,3 @@
-/* https://gal.saop.cc/:splat 301
+https://vns.saop.cc/* https://gal.saop.cc/:splat 301!
+http://vns.saop.cc/* https://gal.saop.cc/:splat 301!
 /* /404 404

--- a/static/vercel.json
+++ b/static/vercel.json
@@ -1,19 +1,14 @@
 {
   "redirects": [
     {
-      "source": "/(.*)",
-      "destination": "https://gal.saop.cc/$1",
+      "source": "/:path(.*)",
+      "has": [{ "type": "host", "value": "vns.saop.cc" }],
+      "destination": "https://gal.saop.cc/:path",
       "statusCode": 301
     }
   ],
   "routes": [
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "status": 404,
-      "dest": "/404"
-    }
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "status": 404, "dest": "/404" }
   ]
 }


### PR DESCRIPTION
- Add a script in head.html to redirect from vns.saop.cc to gal.saop.cc.
- Update _redirects to include specific rules for both HTTP and HTTPS traffic from vns.saop.cc to gal.saop.cc.
- Modify vercel.json to set up a redirect for all paths from vns.saop.cc to gal.saop.cc while preserving 404 handling.