### PR TITLE
Update Hugo configuration and GitHub Actions workflow

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DART_SASS_VERSION: 1.98.0
-      HUGO_VERSION: 0.159.0
+      HUGO_VERSION: 0.159.1
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:
@@ -103,7 +103,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         id: deployment
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/hugo.toml
+++ b/hugo.toml
@@ -227,4 +227,4 @@ isPlainText = true
 permalinkable = false
 
 [outputs]
-home = ["HTML", "RSS", "LLMS", "SW"]
+home = ["HTML", "RSS", "JSON", "LLMS", "SW"]

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,0 +1,5 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range .Site.RegularPages -}}
+    {{- $.Scratch.Add "index" (dict "title" .Title "tags" .Params.tags "categories" .Params.categories "contents" .Plain "permalink" .Permalink) -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
- Change home output format in hugo.toml to include JSON.
- Upgrade Hugo version in GitHub Actions workflow to 0.159.1.
- Update action version for peaceiris/actions-gh-pages to v4 for deployment.