### PR TITLE
Replace service worker with self-unregistering tombstone

### DIFF
--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -15,38 +15,6 @@
       new SwupBodyClassPlugin(),
     ],
   });
-
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', async function () {
-      try {
-        var reg = await navigator.serviceWorker.register('/sw.js');
-        setInterval(function () { reg.update(); }, 3600000);
-
-        reg.addEventListener('updatefound', function () {
-          var newWorker = reg.installing;
-          if (!newWorker) return;
-          newWorker.addEventListener('statechange', function () {
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              newWorker.postMessage({ type: 'SKIP_WAITING' });
-            }
-          });
-        });
-
-        var refreshing = false;
-        navigator.serviceWorker.addEventListener('controllerchange', function () {
-          if (refreshing) return;
-          refreshing = true;
-          window.location.reload();
-        });
-      } catch (e) {
-        console.error('SW registration failed:', e);
-      }
-    });
-
-    swup.hooks.on('page:view', function () {
-      navigator.serviceWorker.getRegistration().then(function (r) { if (r) r.update(); });
-    });
-  }
 </script>
 <script src="https://registry.npmmirror.com/medium-zoom/latest/files/dist/medium-zoom.min.js"></script>
 {{ partialCached "head/js.html" . }}

--- a/layouts/home.sw.js
+++ b/layouts/home.sw.js
@@ -1,85 +1,11 @@
-const CACHE_VERSION = '{{ now.Unix }}';
-const CACHE_NAME = `vns-${CACHE_VERSION}`;
-
-const PRECACHE_URLS = [
-  '/',
-  '/manifest.json',
-  '/img/logo.svg',
-  '/css/normalize.css',
-  '/js/Swup.umd.js',
-  {{ range .Site.Pages }}{{ if and (not .IsNode) (eq .Type "p") }}{{ if le (len .RelPermalink) 60 }}'{{ .RelPermalink }}',
-  {{ end }}{{ end }}{{ end }}
-];
-
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => cache.addAll(PRECACHE_URLS))
-  );
-});
+// Tombstone: 清缓存并注销自身。可在所有旧用户更新后一并删除此文件、
+// hugo.toml 的 [outputFormats.SW] 与 outputs.home 中的 "SW"。
+self.addEventListener('install', () => self.skipWaiting());
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys()
-      .then((keys) => Promise.all(
-        keys.filter((k) => k.startsWith('vns-') && k !== CACHE_NAME)
-            .map((k) => caches.delete(k))
-      ))
-      .then(() => self.clients.claim())
-  );
-});
-
-self.addEventListener('fetch', (event) => {
-  const { request } = event;
-  const url = new URL(request.url);
-
-  if (request.method !== 'GET') return;
-  if (url.origin !== self.location.origin) return;
-
-  if (request.mode === 'navigate' || request.headers.get('accept')?.includes('text/html')) {
-    event.respondWith(networkFirst(request));
-    return;
-  }
-
-  if (/\.(js|css|woff2?|svg|png|jpe?g|webp|avif|gif|ico)$/.test(url.pathname)) {
-    event.respondWith(cacheFirst(request));
-    return;
-  }
-
-  event.respondWith(networkFirst(request));
-});
-
-async function cacheFirst(request) {
-  const cached = await caches.match(request);
-  if (cached) return cached;
-  try {
-    const response = await fetch(request);
-    if (response.ok) {
-      const cache = await caches.open(CACHE_NAME);
-      cache.put(request, response.clone());
-    }
-    return response;
-  } catch {
-    return new Response('Offline', { status: 503 });
-  }
-}
-
-async function networkFirst(request) {
-  try {
-    const response = await fetch(request);
-    if (response.ok) {
-      const cache = await caches.open(CACHE_NAME);
-      cache.put(request, response.clone());
-    }
-    return response;
-  } catch {
-    const cached = await caches.match(request);
-    return cached || new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/html' } });
-  }
-}
-
-self.addEventListener('message', (event) => {
-  if (event.data?.type === 'SKIP_WAITING') {
-    self.skipWaiting();
-  }
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    await self.registration.unregister();
+  })());
 });


### PR DESCRIPTION
The previous SW precached 145 post pages on first visit, invalidated its entire cache on every build (timestamp-versioned), and force-reloaded clients on update — all costly for marginal benefit on a static blog.

Strip the registration logic and replace home.sw.js with a tombstone that clears caches and unregisters itself, so existing clients are cleaned up on their next visit. The output format and template can be removed once old SWs have rolled over.