### PR TITLE
Fix layout offset, illegal HTML nesting, and missing CSS variables

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -735,16 +735,30 @@ function rv() {
             .filter((url) => url !== "{{ .Site.BaseURL }}");
 
           if (!posts || posts.length === 0) {
-            document.body.innerHTML =
-              "<p>No random pages found. Please try again.</p>";
+            Swal.fire({
+              icon: "info",
+              title: "没有可用的随机页面",
+              text: "稍后再试试吧～",
+              toast: true,
+              position: "top",
+              showConfirmButton: false,
+              timer: 3000,
+            });
             return;
           }
           const randomUrl = posts[Math.floor(Math.random() * posts.length)];
           swup.navigate(randomUrl);
         })
         .catch((error) => {
-          document.body.innerHTML =
-            "<p>Error loading random page. Please try again.</p>";
+          Swal.fire({
+            icon: "error",
+            title: "随机页面加载失败",
+            text: "网络好像不太给力，稍后再试～",
+            toast: true,
+            position: "top",
+            showConfirmButton: false,
+            timer: 3000,
+          });
         });
     });
   }

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -11,7 +11,7 @@ html {
 
 body {
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 148px;
   font-family:
     HarmonyOS_Regular,
     -apple-system,
@@ -217,6 +217,19 @@ main {
       overflow-wrap: break-word;
     }
   }
+}
+
+.content {
+  p {
+    margin: 0 0 1em;
+  }
+}
+
+sup#busuanzi_value_page_pv,
+sup.busuanzi_value_page_pv {
+  display: inline-block;
+  min-width: 2em;
+  text-align: left;
 }
 
 main kbd,
@@ -966,6 +979,10 @@ pre:hover .copy-btn {
 }
 
 @media (max-width: 1288px) {
+  body {
+    padding-left: 0;
+  }
+
   #caution-bg {
     width: 90% !important;
     padding: 20px;

--- a/assets/sass/_root.scss
+++ b/assets/sass/_root.scss
@@ -5,6 +5,10 @@
   --border-color: rgba(200, 200, 200, 1);
   --text-color: #333333;
   --link-color: #007bff;
+  --link-hover-color: #0056b3;
+  --content-bg: #ffffff;
+  --body-bg: #f7f7f7;
+  --meta-color: #6c757d;
   --table-row-odd-bg-color: #f9f9f9;
   --table-row-hover-bg-color: #f5f5f5;
   --highlight-background: #f3f3f3;
@@ -24,6 +28,10 @@
     --border-color: rgba(250, 250, 250, 0.3);
     --text-color: #f8f9fa;
     --link-color: #4dabf7;
+    --link-hover-color: #74c0fc;
+    --content-bg: #2a2a2a;
+    --body-bg: #1f1f1f;
+    --meta-color: #adb5bd;
     --table-row-odd-bg-color: #282828;
     --table-row-hover-bg-color: #363636;
     --highlight-background: #3b3b3b;

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -28,7 +28,6 @@
   </button>
 </div>
 <span id="fps"></span>
-<script src="https://registry.npmmirror.com/instant.page/latest/files/instantpage.js" type="module"></script>
 <script defer src="https://registry.npmmirror.com/mouse-firework/latest/files/dist/index.umd.js"
   fetchpriority="low"></script>
 <script async src="https://registry.npmmirror.com/weblive2d/latest/files/js/autoload.js" fetchpriority="low"></script>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,7 +1,6 @@
 {{ define "main" }}
 <article class="article-main">
   <section>
-    <p>
     <div class="image-zoom">
       <img data-src="https://api.illlights.com/v1/img" alt="Random Image" src="https://api.illlights.com/v1/img"
         data-zoomable />
@@ -11,7 +10,6 @@
       <a class="post-edit-link" href="{{ .Site.Params.contentEdit }}{{ with .File }}{{ .Path }}{{ end }}"
         rel="external nofollow noreferrer" title="编辑" target="_blank"><i class="fas fa-pencil-alt"></i></a>
     </h1>
-    </p>
   </section>
   {{ .Content }} {{ $paginator := .Paginate (where .Site.RegularPages "Type"
   "p") }} {{ range $paginator.Pages.ByLastmod.Reverse.ByWeight }}


### PR DESCRIPTION
- Remove invalid <p> wrapping <div>/<h1> on the home page that broke swup transitions
- Add body padding-left:148px so .swup-parallel no longer overlaps the fixed 148px sidebar; reset to 0 below the 1288px breakpoint where the sidebar becomes a slide-in drawer
- Replace document.body.innerHTML wipeouts in the random-page fallback with a Swal toast (Chinese copy)
- Define previously-undefined --link-hover-color, --content-bg, --body-bg and --meta-color used by _ai-review.scss (light + dark)
- Drop instant.page since swup PreloadPlugin already handles hover-preloading
- Add .content p { margin: 0 0 1em } so article paragraphs no longer stick together
- Stabilize busuanzi sup counter with min-width to prevent H1 reflow on async inject