### PR TITLE
Migrate search to Pagefind Component UI

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,33 +1,26 @@
 // 站点搜索与导航助手：search / 随机跳转 / 快捷键 / 18+ 验证
-// 依赖外部全局：PagefindUI / swup / Swal / window.localStorage
+// 依赖外部全局：PagefindComponents（Pagefind Component UI）/ swup / Swal / window.localStorage
 
 export function initSearch() {
-  var searchContainer = document.querySelector("#search");
-  if (searchContainer) {
-    var pagefind = new PagefindUI({
-      element: "#search",
-      pageSize: 10,
-      showSubResults: true,
-      resetStyles: false,
-    });
+  // Pagefind Component UI 的 <pagefind-*> 组件会自动连接并工作，无需手动实例化。
+  // 这里只负责 ?q=keyword 深链：进入 /search/?q=xxx 时自动填入并执行搜索。
+  if (!document.querySelector("pagefind-input")) return;
 
-    // 支持 URL 参数直接搜索，如 /search/?q=keyword
-    var urlParams = new URLSearchParams(window.location.search);
-    var query = urlParams.get("q");
-    if (query) {
-      // 延迟确保 PagefindUI 完全初始化
-      setTimeout(function () {
-        var searchInput = searchContainer.querySelector(
-          ".pagefind-ui__search-input",
-        );
-        if (searchInput) {
-          searchInput.value = query;
-          // 触发 input 事件让 PagefindUI 执行搜索
-          searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-        }
-      }, 100);
+  var query = new URLSearchParams(window.location.search).get("q");
+  if (!query) return;
+
+  // <head> 的 module 脚本会挂载 window.PagefindComponents：首次硬加载时它（defer）
+  // 在 DOMContentLoaded 前已执行，swup 软导航时也已存在。保险起见轮询等待就绪后
+  // 再触发；triggerSearch 会自动把查询词同步到输入框的显示值。
+  var attempts = 0;
+  (function run() {
+    var pf = window.PagefindComponents;
+    if (pf && pf.getInstanceManager) {
+      pf.getInstanceManager().getInstance("default").triggerSearch(query);
+      return;
     }
-  }
+    if (attempts++ < 50) setTimeout(run, 100);
+  })();
 }
 
 export function initGalPopup() {

--- a/assets/sass/_search.scss
+++ b/assets/sass/_search.scss
@@ -1,283 +1,69 @@
-.pagefind-ui {
-  --pf-primary: #3b82f6;
-  --pf-text: #374151;
-  --pf-text-muted: #6b7280;
-  --pf-bg: #ffffff;
-  --pf-bg-hover: #f3f4f6;
-  --pf-border: #e5e7eb;
-  --pf-radius: 12px;
-  --pf-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1),
-    0 8px 10px -6px rgba(0, 0, 0, 0.1);
+// 搜索页样式 —— Pagefind Component UI 主题
+//
+// Component UI（1.5.0+）的 <pagefind-*> 组件用 Shadow DOM 封装，并对宿主元素施加
+// `all: initial`：站点的字体/颜色不会级联进组件内部，唯一的定制入口是这组 `--pf-*`
+// 自定义属性（CSS 变量能穿透 Shadow DOM 边界，按继承就近原则生效）。
+//
+// 关键：本站主样式表在 <head> 中先于 pagefind-component-ui.css 加载，而后者也在
+// `:root` 写了一套 `--pf-*` 默认值（同特异性 + 后加载会盖掉我们写在 `:root` 的覆盖）。
+// 因此把变量挂在 `.pf-search` 上 —— 它是各组件更近的祖先，按继承就近胜出，
+// 不受样式表加载顺序影响（已在浏览器中验证生效）。
+
+.pf-search {
+  // —— 主题变量（亮色）——
   --pf-font: system-ui, -apple-system, sans-serif;
+  --pf-border-radius: 12px;
 
-  font-family: var(--pf-font);
-  color: var(--pf-text);
-  line-height: 1.5;
+  --pf-text: #374151;
+  --pf-text-secondary: #6b7280;
+  --pf-text-muted: #6b7280;
+  --pf-background: #ffffff;
+  --pf-border: #e5e7eb;
+  --pf-border-focus: #3b82f6;
+  --pf-hover: #f3f4f6;
+  --pf-skeleton: #e5e7eb; // 加载骨架屏底色
+  --pf-skeleton-shine: #f3f4f6; // 骨架屏微光
+  --pf-mark: #b45309; // 命中词文字色（组件未暴露高亮背景变量）
+  --pf-outline-focus: #3b82f6;
+
+  --pf-input-height: 48px;
+  --pf-input-font-size: 16px; // ≥16px 避免 iOS 聚焦放大
+  --pf-result-title-font-size: 1rem;
+  --pf-result-excerpt-font-size: 0.9rem;
+  --pf-image-width: 120px;
+  --pf-image-height: 80px;
+
+  --pf-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.06);
+  --pf-shadow-md: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
+  --pf-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.2);
+
+  // —— 布局：输入框 / 摘要 / 结果纵向排列 ——
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   width: 100%;
-  box-sizing: border-box;
-
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-
-  &__form {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    width: 100%;
-    margin: 0 auto;
-  }
-
-  &__search-input {
-    flex: 1;
-    height: 48px;
-    padding: 0 16px;
-    font-size: 1rem;
-    color: var(--pf-text);
-    background: var(--pf-bg);
-    border: 2px solid var(--pf-border);
-    border-radius: var(--pf-radius);
-    outline: none;
-    transition: all 0.2s ease;
-    appearance: none;
-
-    padding-right: 16px !important;
-
-    &:focus {
-      border-color: var(--pf-primary);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
-    }
-
-    &::placeholder {
-      color: #9ca3af;
-    }
-  }
-
-  &__search-clear {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 48px;
-    padding: 0 16px;
-
-    background-color: var(--pf-bg-hover);
-    color: var(--pf-text-muted);
-    border: 1px solid var(--pf-border);
-    border-radius: var(--pf-radius);
-    font-size: 0.9rem;
-    font-weight: 500;
-    cursor: pointer;
-    white-space: nowrap;
-
-    width: 0;
-    padding: 0;
-    margin: 0;
-    opacity: 0;
-    border-width: 0;
-    overflow: hidden;
-    transform: translateX(-10px);
-    pointer-events: none;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-
-    &:hover {
-      background-color: #fee2e2;
-      color: #ef4444;
-    }
-
-    .pagefind-ui__search-input:not(:placeholder-shown) ~ & {
-      width: auto;
-      padding: 0 16px;
-      opacity: 1;
-      border-width: 1px;
-      transform: translateX(0);
-      pointer-events: auto;
-    }
-  }
-
-  &__drawer {
-    position: absolute;
-    top: calc(100% + 12px);
-    left: 0;
-    right: 0;
-    background: var(--pf-bg);
-    border-radius: var(--pf-radius);
-    box-shadow: var(--pf-shadow);
-    border: 1px solid var(--pf-border);
-    overflow: hidden;
-
-    &:empty {
-      display: none;
-    }
-  }
-
-  &__results-area {
-    max-height: 70vh;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-  }
-
-  &__message {
-    padding: 16px;
-    margin: 0;
-    font-size: 0.9rem;
-    color: var(--pf-text-muted);
-    background: var(--pf-bg-hover);
-    border-bottom: 1px solid var(--pf-border);
-    font-weight: 500;
-  }
-
-  &__results {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  &__result {
-    display: flex;
-    gap: 16px;
-    padding: 16px;
-    border-bottom: 1px solid var(--pf-border);
-    transition: background-color 0.2s;
-
-    &:hover {
-      background-color: var(--pf-bg-hover);
-    }
-
-    &:last-child {
-      border-bottom: none;
-    }
-
-    @media (max-width: 640px) {
-      flex-direction: column;
-    }
-  }
-
-  &__result-thumb {
-    flex-shrink: 0;
-    width: 220px;
-    overflow: hidden;
-    background: #f0f0f0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    @media (max-width: 640px) {
-      width: 100%;
-    }
-  }
-
-  &__result-image {
-    width: 100%;
-    display: block;
-  }
-
-  &__result-inner {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  &__result-title {
-    margin: 0;
-    font-size: 1.1rem;
-    font-weight: 600;
-    line-height: 1.4;
-
-    & .pagefind-ui__result-link {
-      color: var(--pf-text);
-      text-decoration: none;
-      transition: color 0.2s;
-
-      &:hover {
-        color: var(--pf-primary);
-        text-decoration: underline;
-        text-decoration-thickness: 2px;
-        text-underline-offset: 2px;
-      }
-    }
-  }
-
-  &__result-excerpt {
-    margin: 0;
-    font-size: 0.9rem;
-    color: var(--pf-text-muted);
-
-    & mark {
-      background: rgba(253, 224, 71, 0.4);
-      color: inherit;
-      padding: 0 2px;
-      border-radius: 2px;
-      font-weight: 600;
-    }
-  }
-
-  &__result-nested {
-    margin-top: 8px;
-    padding-left: 12px;
-    border-left: 3px solid var(--pf-border);
-
-    .pagefind-ui__result-title {
-      font-size: 0.95rem;
-      font-weight: 500;
-      margin-bottom: 4px;
-    }
-
-    .pagefind-ui__result-excerpt {
-      font-size: 0.85rem;
-    }
-
-    &:hover {
-      border-left-color: var(--pf-primary);
-    }
-  }
-
-  &__button {
-    width: 100%;
-    padding: 14px;
-    background: var(--pf-bg);
-    border: none;
-    border-top: 1px solid var(--pf-border);
-    font-size: 0.95rem;
-    color: var(--pf-primary);
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s;
-
-    &:hover {
-      background: var(--pf-bg-hover);
-    }
-  }
+  margin-top: 16px;
 }
 
 @media (prefers-color-scheme: dark) {
-  .pagefind-ui {
-    --pf-primary: #60a5fa;
+  .pf-search {
     --pf-text: #e5e7eb;
+    --pf-text-secondary: #9ca3af;
     --pf-text-muted: #9ca3af;
-    --pf-bg: #1f2937;
-    --pf-bg-hover: #374151;
+    --pf-background: #1f2937;
     --pf-border: #374151;
+    --pf-border-focus: #60a5fa;
+    --pf-hover: #374151;
+    // 关键：必须覆盖骨架屏颜色，否则暗色下会沿用浅色默认值（#eee/#f5f5f5），
+    // 搜索瞬间结果/图片的骨架屏会在深色背景上「闪白」。
+    --pf-skeleton: #374151;
+    --pf-skeleton-shine: #4b5563;
+    --pf-scroll-shadow: rgba(255, 255, 255, 0.08);
+    --pf-mark: #fcd34d;
+    --pf-outline-focus: #60a5fa;
 
-    --pf-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5),
-      0 8px 10px -6px rgba(0, 0, 0, 0.5);
-
-    &__search-clear:hover {
-      background-color: #450a0a;
-      color: #fca5a5;
-    }
-
-    &__result-thumb {
-      background: #111827;
-    }
-
-    &__result-excerpt mark {
-      background: rgba(180, 83, 9, 0.5);
-      color: #fff;
-    }
+    --pf-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+    --pf-shadow-md: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+    --pf-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.5);
   }
 }

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -94,7 +94,8 @@
   src="https://registry.npmmirror.com/@swup/progress-plugin/latest/files/dist/index.umd.js"
   fetchpriority="high"
 ></script>
-<script src="/pagefind/pagefind-ui.js" fetchpriority="high"></script>
+<link href="/pagefind/pagefind-component-ui.css" rel="stylesheet" fetchpriority="high" />
+<script src="/pagefind/pagefind-component-ui.js" type="module" fetchpriority="high"></script>
 <script src="//registry.npmmirror.com/leancloud-storage/latest/files/dist/av-min.js"></script>
 <script src="//registry.npmmirror.com/valine/latest/files/dist/Valine.min.js"></script>
 <link rel="stylesheet" href="https://registry.npmmirror.com/artalk/latest/files/dist/Artalk.css" />

--- a/layouts/search.html
+++ b/layouts/search.html
@@ -2,6 +2,11 @@
 <article class="article-main">
   {{ partial "h1.html" . }}
   <div class="content">{{ .Content }}</div>
-  <div id="search"></div>
+  <pagefind-config bundle-path="/pagefind/" lang="zh"></pagefind-config>
+  <div id="search" class="pf-search">
+    <pagefind-input placeholder="搜索…"></pagefind-input>
+    <pagefind-summary></pagefind-summary>
+    <pagefind-results show-images></pagefind-results>
+  </div>
 </article>
 {{ end }}


### PR DESCRIPTION
Replace the Default UI (PagefindUI / pagefind-ui.js), which 1.5.0 only recommends for legacy setups, with the new Component UI web components. head.html loads pagefind-component-ui.css + .js (module); the search page uses building-block elements (pagefind-config / input / summary / results) with lang=zh and show-images; initSearch is reduced to driving the ?q= deep-link via PagefindComponents.triggerSearch. This also clears the build-time Default UI notice.

_search.scss drops the now-dead .pagefind-ui__* BEM styles (Component UI renders in Shadow DOM) and re-themes via --pf-* custom properties scoped to .pf-search — a closer ancestor than :root, so it beats pagefind own :root defaults regardless of stylesheet load order. Ported the brand palette and dark mode, and themed the loading-skeleton vars for dark mode to fix a white flash while results lazy-loaded on a dark page.