### PR TITLE
Add scannable page QR code (icon button + click-to-enlarge modal)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,7 +11,7 @@ import {
 } from "./home.js";
 import { initAIReview } from "./ai-review.js";
 import { mouseFirework, initLozad, initMediumZoom } from "./media.js";
-import { initSearch, initGalPopup, rv, shortcutKey, initHeadSearch, initHeadNav, initHeaderScroll } from "./search.js";
+import { initSearch, initGalPopup, rv, shortcutKey, initHeadSearch, initHeadNav, initHeaderScroll, initPageQR } from "./search.js";
 import { initImgSearch } from "./imgsearch.js";
 import { initTOCSidebar, initPostSubmissionForm, initValine, fetchDLS, initRankPage } from "./pages.js";
 import { lunar } from "./lunar.js";
@@ -50,6 +50,7 @@ function initializePage() {
     ["initHeadSearch", initHeadSearch],
     ["initHeadNav", initHeadNav],
     ["initHeaderScroll", initHeaderScroll],
+    ["initPageQR", initPageQR],
     ["initImgSearch", initImgSearch],
     ["shortcutKey", shortcutKey],
     ["langCode", langCode],

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -232,6 +232,30 @@ export function initHeaderScroll() {
   apply();
 }
 
+// 页面二维码：点击图标按钮才懒加载二维码并放大成居中模态；点遮罩 / Esc 关闭。
+export function initPageQR() {
+  const wrap = document.querySelector(".page-qr");
+  if (!wrap || wrap._qrBound) return;
+  wrap._qrBound = true;
+  const btn = wrap.querySelector(".page-qr-btn");
+  const modal = wrap.querySelector(".page-qr-modal");
+  const img = modal && modal.querySelector(".page-qr-img");
+  if (!btn || !modal) return;
+  btn.addEventListener("click", () => {
+    if (img && img.dataset.src && !img.getAttribute("src")) img.src = img.dataset.src; // 点击才加载
+    modal.hidden = false;
+  });
+  modal.addEventListener("click", () => { modal.hidden = true; });
+  if (!document._qrEscBound) {
+    document._qrEscBound = true;
+    document.addEventListener("keydown", (e) => {
+      if (e.key !== "Escape") return;
+      const m = document.querySelector(".page-qr-modal");
+      if (m && !m.hidden) m.hidden = true;
+    });
+  }
+}
+
 export function initHeadSearch() {
   const wrap = document.getElementById("hdrSearch");
   const input = document.getElementById("hdrSearchInput");

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -26,6 +26,7 @@ body {
 }
 
 .swup-parallel {
+  position: relative; // 作为页面二维码 .page-qr 的定位参照
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
@@ -276,8 +277,72 @@ table {
   }
 }
 
-.qr-code {
-  max-width: 100px;
+// 页面二维码（参考 Hugo 官网，扫码在手机打开当前页）：内容区标题旁只放一个图标按钮，
+// 点击才懒加载二维码并放大成居中模态——图标小不占地，模态层级极高不会被任何浮动元素挡。
+.page-qr {
+  position: absolute;
+  top: 1.1em;
+  right: 1.1em;
+  z-index: 5;
+
+  @media (max-width: 900px) { display: none; }
+}
+
+.page-qr-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--border-color);
+  border-radius: 9px;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 1.15em;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s, transform 0.2s;
+
+  &:hover {
+    color: var(--link-color);
+    border-color: var(--link-color);
+    transform: scale(1.05);
+  }
+}
+
+.page-qr-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10000; // 高于一切浮动元素，绝不会被挡
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  background: rgba(0, 0, 0, 0.65);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  cursor: zoom-out;
+  animation: qr-fade 0.2s ease;
+
+  &[hidden] { display: none; }
+
+  .page-qr-img {
+    width: min(300px, 72vw);
+    height: auto;
+    padding: 14px;
+    background: #fff;
+    border-radius: 14px;
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.35);
+  }
+  span {
+    color: #fff;
+    font-size: 0.92em;
+    letter-spacing: 0.02em;
+  }
+}
+@keyframes qr-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .highlight {

--- a/layouts/_partials/qr.html
+++ b/layouts/_partials/qr.html
@@ -1,0 +1,14 @@
+{{/* 页面二维码：默认只显示一个图标按钮（不占地、不会被浮动元素挡）；点击才懒加载二维码
+     并放大成居中模态。在 swup 容器内（见 scripts.html），软导航会重渲，二维码始终指向当前页。 */}}
+{{ $page := . }}
+<div class="page-qr">
+  <button type="button" class="page-qr-btn" aria-label="显示本页二维码" title="扫码看本页">
+    <i class="fa fa-qrcode"></i>
+  </button>
+  <div class="page-qr-modal" hidden>
+    {{ with images.QR $page.Permalink (dict "level" "low" "scale" 2 "targetDir" "img") }}
+    <img class="page-qr-img" data-src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="QR code linking to {{ $page.Permalink }}" />
+    {{ end }}
+    <span>扫码在手机上打开本页</span>
+  </div>
+</div>

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -1,6 +1,6 @@
 <script>
   const swup = new Swup({
-    containers: ["#swup", "header", "footer", "#hdrDrawer"],
+    containers: ["#swup", "header", "footer", "#hdrDrawer", ".page-qr"],
     linkSelector: "a[href]:not([data-no-swup])",
     plugins: [
       new SwupParallelPlugin({ containers: ['#swup'] }),

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -11,6 +11,7 @@
   <noscript>请启用 JavaScript</noscript>
   <div class="swup-parallel">
     <main id="swup" class="transition-fade">{{ block "main" . }}{{ end }}</main>
+    {{ partial "qr.html" . }}
   </div>
   <div class="nav-overlay" id="navOverlay"></div>
   <header class="site-header">{{ partial "header.html" . }}</header>


### PR DESCRIPTION
A small QR-code icon sits at the top-right of the content; clicking it lazy-loads the current page's QR and enlarges it into a centered modal (z-index above all floating elements so it can't be covered). Lives in the swup container so it updates per page.