### PR TITLE
Tailwind v4 + Basecoat migration + CI Tailwind CLI fix

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -45,6 +45,14 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install Node dependencies
+        run: |
+          bun install --frozen-lockfile
+          echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Cache Restore
         id: cache-restore
         uses: actions/cache/restore@v6


### PR DESCRIPTION
Brings the Tailwind v4 + Basecoat migration work into main and fixes the deploy build.

## Changes
- Migrate styling from Sass toward Tailwind v4 + Basecoat (build pipeline, app.css, partials).
- **CI fix**: install Tailwind CLI via Bun before the Hugo build. Hugo's `css.TailwindCSS` needs the `tailwindcss` binary in PATH — the previous main build (run #28305099065) failed without it.

## Verification
- Local production build (`HUGO_ENVIRONMENT=production hugo --gc --minify`) succeeds, 708 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)